### PR TITLE
Bytecodeio rate limits from api use milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.0.2
+  * Update rate limit backoff calc
+
 ## 0.0.1
   * Initial commit

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import setup, find_packages
 
 setup(name='tap-skubana',
-      version='0.0.1',
+      version='0.0.2',
       description='Singer.io tap for extracting data from the Skubana API',
       author='scott.coleman@bytecode.io',
       classifiers=['Programming Language :: Python :: 3 :: Only'],

--- a/tap_skubana/client.py
+++ b/tap_skubana/client.py
@@ -120,7 +120,7 @@ class SkubanaClient:
 
         if response.status_code == 429:
             retry_after = int(
-                response.headers.get('x-skubana-quota-retryAfter', 15))
+                response.headers.get('x-skubana-quota-retryAfter', 15000))/1000
             message = 'Rate limit hit - 429 - retrying after {} seconds'.format(
                 retry_after)
             LOGGER.info(message)

--- a/tap_skubana/streams.py
+++ b/tap_skubana/streams.py
@@ -71,7 +71,7 @@ class BaseStream:
     def max_from_replication_dates(self, record):
         date_times = {
             dt: strptime_to_utc(record[dt])
-            for dt in self.valid_replication_keys if record[dt] is not None
+            for dt in self.valid_replication_keys if record.get(dt)
         }
         max_key = max(date_times)
         return self.valid_replication_keys[-1], date_times[max_key]


### PR DESCRIPTION
# Description of change
Exact same changes as https://github.com/singer-io/tap-skubana/pull/3 but rebased to include master changes which have a circle file, which unfortunately is required to pass to merge the PR

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
