### PR TITLE
Fix broken sessions

### DIFF
--- a/tap_skubana/streams.py
+++ b/tap_skubana/streams.py
@@ -233,6 +233,7 @@ class Order(BaseStream):
     bookmark_field = 'modifiedDateFrom'
     endpoint = 'orders'
     version = 'v1.1'
+    limit = 500
 
 
 class StockTransfer(BaseStream):


### PR DESCRIPTION
# Description of change

Every time the tap reaches the Rate Limit for any of the endpoints and sleeps for a certain ammount of time, when it resumes we get the error "Connection reset by peer". This might be due to a [bug in the requests sessions](https://github.com/psf/requests/issues/4664) or maybe the Skubana server not properly closing connections.

Either way, this is why I'm adding a retry to get requests (and also creating the session as a classmethod).

# Changelog:

- Add retry to get requests
- Increase limit for order stream

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
